### PR TITLE
Get count

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,11 +21,11 @@
             "name": "Debug Jest Current File",
             "type": "node",
             "request": "launch",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "runtimeExecutable": "npm",
             "args": [
-                "${relativeFile}",
-                "--config",
-                "jest.config.js"
+                "run",
+                "test:debug",
+                "${relativeFile}"
             ],
             "envFile": "${workspaceFolder}/.env",
             "console": "integratedTerminal",

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -67,14 +67,20 @@ const onRead = async req => {
     folderName,
   );
 
-  const { results } = await srv
+  const { results, numItems } = await srv
     .cmisQuery(repositoryId, query, options)
     .execute(destination);
+
   if (req.query._streaming) {
     return onReadStream(req, results[0]?.succinctProperties);
   }
 
-  return convertCMISDocumentToOData(results, req.target.elements);
+  const response = await convertCMISDocumentToOData(
+    results,
+    req.target.elements,
+  );
+  response.$count = numItems;
+  return response;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   ],
   "scripts": {
     "lint": "npx eslint .",
-    "test": "jest --silent --setupFiles dotenv/config --config jest.config.js"
+    "test": "jest --silent --setupFiles dotenv/config --config jest.config.js",
+    "test:debug": "jest --setupFiles dotenv/config --config jest.config.js"
   },
   "peerDependencies": {
     "@sap/cds": "^7.3.1"

--- a/test/crud/basic/crud.test.js
+++ b/test/crud/basic/crud.test.js
@@ -67,6 +67,24 @@ describe('Sample API test', () => {
     expect(retrievedDocument.id).toEqual(file.id);
   });
 
+  test('get list of objects', async () => {
+    const response = await GET('/crud/Files');
+    expect(response.status).toBe(200);
+  });
+
+  test('count list of objects', async () => {
+    const response = await GET('/crud/Files/$count');
+    expect(response.status).toBe(200);
+    expect(response.data).toBeGreaterThan(0);
+  });
+
+  test('inline count list of objects', async () => {
+    const response = await GET('/crud/Files?$count=true');
+    expect(response.status).toBe(200);
+    expect(response.data?.['@odata.count']).toBeTruthy();
+    expect(response.data['@odata.count']).toBeGreaterThan(0);
+  });
+
   test('download object content', async () => {
     const response = await GET(`/crud/Files('${file.id}')/content`);
     expect(response.status).toBe(200);


### PR DESCRIPTION
fix(cds-plugin):
 - The `$count` was always returning 0. I fixed it to always receive the native count from the CMIS query.

chore(debug):
 - Replaced the `runargs` in `.vscode/launch.json` with the npm scripts `test` and `test:debug`.