### PR TITLE
Change proposal to deal with 1 to many Association and Draft

### DIFF
--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -139,7 +139,11 @@ const onCreate = async req => {
     // nothing to do
   }
 
-  if (folderName) await onCreateFolder(req, folderName);
+  try {
+    if (folderName) await onCreateFolder(req, folderName);
+  } catch (e) {
+    // nothing to do
+  }
 
   const { cmisDocument } = req;
   if (!cmisDocument['cmis:name']) {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -60,7 +60,7 @@ const deriveFolderNameFromNavigation = req => {
   const navigatingFromEntity =
     pathSegments[pathSegments.indexOf(lastNavigationSegment) - 1];
   const entityName = navigatingFromEntity.getEntitySet().getName();
-  const keys = navigatingFromEntity.getKeyPredicates().map(p => p._value);
+  const keys = navigatingFromEntity.getKeyPredicates().filter(p => p._edmRef._ref.name !== 'IsActiveEntity').map(p => p._value);
   return `${entityName}:${keys.join('-')}`;
 };
 


### PR DESCRIPTION
Hi @vneecious 

I created PR to deal with below two points. I am glad if you will check my change and merge to your code base.

1. Skip creating folder when 1 to many association case. (lib/handlers/index.js)
- In (1 Users : many Avatars) case, second Avatars creation failed due to creating folder failed that is prerequisite.
- I changed to skip error (same as #16).
2. Exclude draft status flag from folder name. (lib/util/index.js)
- In case of Users entity is annotated with `@odata.draft.enabled`, folder name was `User:1-false`, because OData V4 draft function has automatically added boolean key `IsActiveEntity`. Currently filtering query in `onRead` function does not work due to this (all Avatars under all Users are displayed even when I specified User ID).
- I added logic to exclude `IsActiveEntity` from list of key. Now folder name is ``User:1` even draft enabled entity, and query is working irrelevant to draft status.