### PR TITLE
Create folder for reading zero document correctly

### DIFF
--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -45,6 +45,12 @@ const onRead = async req => {
     // nothing to do
   }
 
+  try {
+    if (folderName) await onCreateFolder(req, folderName);
+  } catch (e) {
+    // nothing to do
+  }
+
   let keys = req.cmisDocument;
   if (folderName) {
     const { results: queryResults } = await srv


### PR DESCRIPTION
Hi @vneecious,

Based on below background, I would like to update `onRead` function to create folder before finding `parentIds`. 

I am implementing CAP + Fiori Elements (List Report) application for request form with attachments.
I have data model of parent request entity and child SDM entity (1 to many association).
To handle attachments, I am using Custom Section in Object Page and am implementing SAPUI5 UploadSet component.
When creating new request in UI, UploadSet is trying to display list of attachments for new request by specifying folder (derived from draft request ID). 
But currently `onRead` function is displaying all SDM documents because SDM folder is not created yet. It should be zero document.
To prevent such trouble, I would like to create folder before document creation.

Could you check then merge to your repository?