### PR TITLE
Fix and Features

### DIFF
--- a/srv/cmis/client.js
+++ b/srv/cmis/client.js
@@ -181,6 +181,48 @@ module.exports = class CmisClient extends cds.Service {
   }
 
   /**
+   * Sets a content stream to the content stream of the document and refreshes this object afterwards.
+   * If the repository created a new version, this new document is returned. Otherwise, the current document is returned.
+   *
+   * @param {string} repositoryId - Repository ID
+   * @param {string} objectId - The ID of the document.
+   * @param {string} filename - The name of the file (e.g., filename.json).
+   * @param {any} contentStream - The content stream to be appended to the existing content.
+   * @param {BaseCmisOptions & { overwriteFlag?: boolean }} options - Optional parameters to modify the append behavior.
+   * @property options.overwriteFlag - Indicates whether content should be overwritten. Defaults to `true`.
+   *
+   * @returns {OpenApiRequestBuilder}
+   */
+  setContentStream(
+    repositoryId,
+    objectId,
+    filename,
+    contentStream,
+    options = {
+      overwriteFlag: true,
+    },
+  ) {
+    const { config = {}, ...optionalParameters } = options;
+
+    const bodyData = {
+      cmisaction: 'setContent',
+      objectId,
+      ...this.globalParameters,
+      ...optionalParameters,
+    };
+
+    const requestBody = jsonToFormdata(bodyData);
+    if (contentStream) requestBody.append('content', contentStream, filename);
+
+    const request = builder.createBrowserRootByRepositoryId(
+      repositoryId,
+      requestBody,
+    );
+
+    return this._buildRequest(request, config);
+  }
+
+  /**
    * Appends a content stream to the content stream of the document and refreshes this object afterwards.
    * If the repository created a new version, this new document is returned. Otherwise, the current document is returned.
    *
@@ -435,7 +477,7 @@ module.exports = class CmisClient extends cds.Service {
       ...optionalParameters,
     };
 
-    const request = api.createBrowserRootByRepositoryId(
+    const request = builder.createBrowserRootByRepositoryId(
       repositoryId,
       requestBody,
     );

--- a/srv/cmis/client.js
+++ b/srv/cmis/client.js
@@ -132,35 +132,14 @@ module.exports = class CmisClient extends cds.Service {
    *
    * @param {string} repositoryId - Repository ID
    * @param {string} objectId - Identifier of the object.
-   * @param { { filter?: string;maxItems?: number;skipCount?: number;orderBy?: string;includeAllowableActions?: boolean;includePathSegment?: boolean;includeRelationships?: 'none' | 'source' | 'target' | 'both';renditionFilter?: string;includePolicyIds?: boolean; } & BaseCmisOptions} options - Configuration options for the request.
-   * @property {string} [options.filter] - List of property query names to return (e.g., 'cmis:name,description').
-   *                                       For secondary type properties, follow the format: <secondaryTypeQueryName>.<propertyQueryName>.
-   * @property {number} [options.maxItems] - Maximum number of children to return.
-   * @property {number} [options.skipCount] - Number of initial results to skip.
-   * @property {string} [options.orderBy] - A comma-separated list of query names and an optional ascending modiﬁer "ASC" or descending modiﬁer "DESC" for each query name.
-   *                                        If the modiﬁer is not stated, "ASC" is assumed
    * @property {boolean} [options.includeAllowableActions] - Whether to include allowable actions for each child.
-   * @property {boolean} [options.includePathSegment] - Whether to include the path segment for each child.
-   * @property {"none" | "source" | "target" | "both"} [options.includeRelationships] - Scope of the relationships to include.
-   * @property {string} [options.renditionFilter] - Defines the renditions to be included in the response.
-   *                                               Examples for `renditionFilter`:
-   *                                               - `*`: Include all renditions.
-   *                                               - `cmis:thumbnail`: Include only thumbnails.
-   *                                               - `image/*`: Include all image renditions.
-   *                                               - `application/pdf,application/x-shockwave-flash`: Include web ready renditions.
-   *                                               - `cmis:none`: Exclude all renditions (Default).
-   * @property {boolean} [options.includePolicyIds] - Indicates whether the repository should return the IDs of policies applied to the object. If set to `true`, the repository is required to return these IDs.
    * @returns {OpenApiRequestBuilder}
    */
 getAllVersions(
   repositoryId,
   objectId,
   options = {
-    filter: '*',
-    includeAllowableActions: false,
-    includePathSegment: false,
-    includeRelationships: 'none',
-    includePolicyIds: false,
+    includeAllowableActions: true
   },
 ) {
   const { config = {}, ...optionalParameters } = options;

--- a/srv/cmis/client.js
+++ b/srv/cmis/client.js
@@ -127,6 +127,59 @@ module.exports = class CmisClient extends cds.Service {
     return this._buildRequest(request, config);
   }
 
+/**
+   * Retrieves the version details of a specified object within the CMIS repository.
+   *
+   * @param {string} repositoryId - Repository ID
+   * @param {string} objectId - Identifier of the object.
+   * @param { { filter?: string;maxItems?: number;skipCount?: number;orderBy?: string;includeAllowableActions?: boolean;includePathSegment?: boolean;includeRelationships?: 'none' | 'source' | 'target' | 'both';renditionFilter?: string;includePolicyIds?: boolean; } & BaseCmisOptions} options - Configuration options for the request.
+   * @property {string} [options.filter] - List of property query names to return (e.g., 'cmis:name,description').
+   *                                       For secondary type properties, follow the format: <secondaryTypeQueryName>.<propertyQueryName>.
+   * @property {number} [options.maxItems] - Maximum number of children to return.
+   * @property {number} [options.skipCount] - Number of initial results to skip.
+   * @property {string} [options.orderBy] - A comma-separated list of query names and an optional ascending modiﬁer "ASC" or descending modiﬁer "DESC" for each query name.
+   *                                        If the modiﬁer is not stated, "ASC" is assumed
+   * @property {boolean} [options.includeAllowableActions] - Whether to include allowable actions for each child.
+   * @property {boolean} [options.includePathSegment] - Whether to include the path segment for each child.
+   * @property {"none" | "source" | "target" | "both"} [options.includeRelationships] - Scope of the relationships to include.
+   * @property {string} [options.renditionFilter] - Defines the renditions to be included in the response.
+   *                                               Examples for `renditionFilter`:
+   *                                               - `*`: Include all renditions.
+   *                                               - `cmis:thumbnail`: Include only thumbnails.
+   *                                               - `image/*`: Include all image renditions.
+   *                                               - `application/pdf,application/x-shockwave-flash`: Include web ready renditions.
+   *                                               - `cmis:none`: Exclude all renditions (Default).
+   * @property {boolean} [options.includePolicyIds] - Indicates whether the repository should return the IDs of policies applied to the object. If set to `true`, the repository is required to return these IDs.
+   * @returns {OpenApiRequestBuilder}
+   */
+getAllVersions(
+  repositoryId,
+  objectId,
+  options = {
+    filter: '*',
+    includeAllowableActions: false,
+    includePathSegment: false,
+    includeRelationships: 'none',
+    includePolicyIds: false,
+  },
+) {
+  const { config = {}, ...optionalParameters } = options;
+
+  const requestBody = {
+    objectId,
+    cmisselector: 'versions',
+    ...this.globalParameters,
+    ...optionalParameters,
+  };
+
+  const request = builder.getBrowserRootByRepositoryId(
+    repositoryId,
+    requestBody,
+  );
+
+  return this._buildRequest(request, config);
+}
+
   /**
    * Retrieves the details of a specified object within the CMIS repository.
    *

--- a/test/cmis/basic-repository.test.js
+++ b/test/cmis/basic-repository.test.js
@@ -88,6 +88,22 @@ describe('CMIS Client', () => {
     );
   });
 
+  test('set content stream', async () => {
+    const srv = await cds.connect.to('cmis-client');
+    const result = await srv
+      .setContentStream(
+        repository.id,
+        document.succinctProperties['cmis:objectId'],
+        document.succinctProperties['cmis:name'],
+        'updated content by setContentStream',
+      )
+      .execute(destination);
+
+    expect(result.succinctProperties['cmis:contentStreamLength']).not.toBe(
+      document.succinctProperties['cmis:contentStreamLength'],
+    );
+  });
+
   test('CMIS Query', async () => {
     const srv = await cds.connect.to('cmis-client');
     const result = await srv


### PR DESCRIPTION
- Fix cancelCheckOut code referred to `const request = api.createBrowserRootByRepositoryId` instead of `const request = builder.createBrowserRootByRepositoryId`
- Add SetContentStream to overwrite file with new content
- Add getAllVersions to retrieve all versions of an object if version management is enabled - to be used for checkin/out validation
