### PR TITLE
fix: Add 'sdm-admin' to initializePlugin

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -23,6 +23,7 @@ async function initializePlugin(services) {
   getSettings();
 
   cds.env.requires['cmis-client'] = { impl: `${__dirname}/srv/cmis/client` };
+  cds.env.requires['sdm-admin'] = { impl: `${__dirname}/srv/sdm/admin` };
 
   // Get all services that has any entity annotated with @Sdm.Entity
   sdmServices.push(...extractServicesWithAnnotations(services));


### PR DESCRIPTION
### Minor fix

- `cds.connect.to('sdm-admin')` fails if no `impl` is specified.
- Add automatic initialisation of 'sdm-admin' for `cds.connect.to('sdm-admin')`