### PR TITLE
New `cmis-client` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Avaiable API:
  - [x] Check Out Document: `checkOut`
  - [x] CMIS Query: `cmisQuery`
  - [x] Create Document: `createDocument`
- - [ ] Create Document from Source: `TODO`
+ - [x] Create Document from Source: `createDocumentFromSource`
  - [ ] Create Favorite: `TODO`
  - [X] Create Folder: `createFolder`
  - [ ] Create Link: `TODO`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After setting up, check your configuration to make sure everything is okay.
 
 ## Additional Features
 
-1. File URL
+### 1. File URL
 
 Obtain a direct URL to the document by specifying `type: 'link'` within the `@Sdm.Field` annotation.
 
@@ -72,13 +72,13 @@ Obtain a direct URL to the document by specifying `type: 'link'` within the `@Sd
     url: String @Sdm.Field : { type : 'link' };
 ```
 
-2. CMIS Client
+### 2. CMIS Client
 
 If the entity annotations don't meet your needs, you can use the CMIS Client to implement your own logic.
 
 This service follows the specs of [SAP Document Management Service, Integration Options - CMIS](https://api.sap.com//package/SAPDocumentManagementServiceIntegrationOptionCMISAPI/rest) from [SAP Business Accelerator Hub](https://api.sap.com/).
 
-### Usage:
+#### Usage:
 
 ```javascript
 const client = await cds.connect.to('cmis-client');
@@ -90,11 +90,52 @@ await client
 
 Check `test/cmis` for more examples.
 
-3. SDM Administrative Operations
+Avaiable API:
+ - [x] Add Access Control Entries: `getACLProperty`
+ - [x] Append Content Stream: `appendContentStream`
+ - [x] Cancel Check Out Document: `cancelCheckOut`
+ - [x] Check In Document: `checkIn`
+ - [x] Check Out Document: `checkOut`
+ - [x] CMIS Query: `cmisQuery`
+ - [x] Create Document: `createDocument`
+ - [] Create Document from Source: `TODO`
+ - [] Create Favorite: `TODO`
+ - [X] Create Folder: `createFolder`
+ - [] Create Link: `TODO`
+ - [] Create Secondary Type: `TODO`
+ - [] Create Share: `TODO`
+ - [X] Delete Object: `deleteObject`
+ - [] Delete Tree: `TODO`
+ - [X] Download a File: `downloadFile`
+ - [X] Fetch Repository: `fetchRepository`
+ - [] Generate Thumbnail: `TODO`
+ - [X] Get Access Control List: `getACLProperty`
+ - [] Get Allowable Actions: `TODO`
+ - [] Get Children: `TODO`
+ - [] Get Deleted Children: `TODO`
+ - [] Get Descendants: `TODO`
+ - [] Get Folder Tree: `TODO`
+ - [X] Get Object: `getObject`
+ - [] Get Parent: `TODO`
+ - [] Get Properties: `TODO`
+ - [] Get Type Children: `TODO`
+ - [] Get Type Definition: `TODO`
+ - [] Get Type Descendants: `TODO`
+ - [] Move Object: `TODO`
+ - [] Permanently Remove the Object: `TODO`
+ - [X] Remove Access Control Entries: `TODO`
+ - [] Restore Object: `TODO`
+ - [] Update Folder, Document, Link Object: `TODO`
+ - [X] Update Properties: `updateProperties`
+ - [] ZIP Content Creation: `TODO`
+ - [] ZIP Content Download: `TODO`
+ - [] ZIP Extract and Upload: `TODO`
+
+### 3. SDM Administrative Operations
 
 There's also a service for admin tasks, like adding a new repository. This service comes from the [Document Management Service, Integration Options - AdminAPI](https://api.sap.com/api/AdminAPI/overview).
 
-### Usage:
+#### Usage:
 
 ```javascript
 const admin = await cds.connect.to('sdm-admin');

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After setting up, check your configuration to make sure everything is okay.
 
 ## Additional Features
 
-1. File URL
+### 1. File URL
 
 Obtain a direct URL to the document by specifying `type: 'link'` within the `@Sdm.Field` annotation.
 
@@ -72,13 +72,13 @@ Obtain a direct URL to the document by specifying `type: 'link'` within the `@Sd
     url: String @Sdm.Field : { type : 'link' };
 ```
 
-2. CMIS Client
+### 2. CMIS Client
 
 If the entity annotations don't meet your needs, you can use the CMIS Client to implement your own logic.
 
 This service follows the specs of [SAP Document Management Service, Integration Options - CMIS](https://api.sap.com//package/SAPDocumentManagementServiceIntegrationOptionCMISAPI/rest) from [SAP Business Accelerator Hub](https://api.sap.com/).
 
-### Usage:
+#### Usage:
 
 ```javascript
 const client = await cds.connect.to('cmis-client');
@@ -90,11 +90,52 @@ await client
 
 Check `test/cmis` for more examples.
 
-3. SDM Administrative Operations
+Avaiable API:
+ - [x] Add Access Control Entries: `addACLProperty`
+ - [x] Append Content Stream: `appendContentStream`
+ - [x] Cancel Check Out Document: `cancelCheckOut`
+ - [x] Check In Document: `checkIn`
+ - [x] Check Out Document: `checkOut`
+ - [x] CMIS Query: `cmisQuery`
+ - [x] Create Document: `createDocument`
+ - [ ] Create Document from Source: `TODO`
+ - [ ] Create Favorite: `TODO`
+ - [X] Create Folder: `createFolder`
+ - [ ] Create Link: `TODO`
+ - [ ] Create Secondary Type: `TODO`
+ - [ ] Create Share: `TODO`
+ - [X] Delete Object: `deleteObject`
+ - [ ] Delete Tree: `TODO`
+ - [X] Download a File: `downloadFile`
+ - [X] Fetch Repository: `fetchRepository`
+ - [ ] Generate Thumbnail: `TODO`
+ - [X] Get Access Control List: `getACLProperty`
+ - [ ] Get Allowable Actions: `TODO`
+ - [ ] Get Children: `TODO`
+ - [ ] Get Deleted Children: `TODO`
+ - [ ] Get Descendants: `TODO`
+ - [ ] Get Folder Tree: `TODO`
+ - [X] Get Object: `getObject`
+ - [ ] Get Parent: `TODO`
+ - [ ] Get Properties: `TODO`
+ - [ ] Get Type Children: `TODO`
+ - [ ] Get Type Definition: `TODO`
+ - [ ] Get Type Descendants: `TODO`
+ - [ ] Move Object: `TODO`
+ - [ ] Permanently Remove the Object: `TODO`
+ - [X] Remove Access Control Entries: `removeACLProperty`
+ - [ ] Restore Object: `TODO`
+ - [ ] Update Folder, Document, Link Object: `TODO`
+ - [X] Update Properties: `updateProperties`
+ - [ ] ZIP Content Creation: `TODO`
+ - [ ] ZIP Content Download: `TODO`
+ - [ ] ZIP Extract and Upload: `TODO`
+
+### 3. SDM Administrative Operations
 
 There's also a service for admin tasks, like adding a new repository. This service comes from the [Document Management Service, Integration Options - AdminAPI](https://api.sap.com/api/AdminAPI/overview).
 
-### Usage:
+#### Usage:
 
 ```javascript
 const admin = await cds.connect.to('sdm-admin');

--- a/srv/cmis/client.js
+++ b/srv/cmis/client.js
@@ -259,6 +259,43 @@ module.exports = class CmisClient extends cds.Service {
   }
 
   /**
+   * Creates a copy of a document from the source folder into a targeted folder without changing any properties of the document.
+   *
+   * @param {string} repositoryId - The Repository ID.
+   * @param {string} sourceId - The Object ID that will be copied.
+   * @param {string} targetFolderId - The Folder ID where the new object will be created.
+   * @param {WriteOptions} options - Options for document creation.
+   *
+   * @returns {OpenApiRequestBuilder}
+   */
+  createDocumentFromSource(
+    repositoryId,
+    sourceId,
+    targetFolderId,
+    options = {},
+  ) {
+    const { config = {}, ...optionalParameters } = options;
+
+    const bodyData = {
+      cmisaction: 'createDocumentFromSource',
+      objectId: targetFolderId,
+      sourceId,
+      ...this.globalParameters,
+      ...optionalParameters,
+    };
+
+    const requestBody = jsonToFormdata(bodyData);
+
+    let request;
+    request = builder.createBrowserRootByRepositoryId(
+      repositoryId,
+      requestBody,
+    );
+
+    return this._buildRequest(request, config);
+  }
+
+  /**
    * Retrieves the version details of a specified object within the CMIS repository.
    *
    * @param {string} repositoryId - Repository ID

--- a/srv/cmis/converters/object-to-query-array-params.js
+++ b/srv/cmis/converters/object-to-query-array-params.js
@@ -1,0 +1,41 @@
+/**
+ * Converts an array of input objects into a query array format.
+ *
+ * This function takes an array of input objects and converts each object's key-value pairs
+ * into the query array format often used in URL query parameters. If a value is an array,
+ * it further breaks down each array item with its index.
+ *
+ * Example:
+ *
+ * Input:
+ * [{ "username": "John", "permissions": ["read", "write"] }]
+ *
+ * Output:
+ * {
+ *   "username[0]": "John",
+ *   "permissions[0][0]": "read",
+ *   "permissions[0][1]": "write"
+ * }
+ *
+ * @param input - The array of input objects to be transformed.
+ * @returns The transformed object in query array format.
+ */
+module.exports = function convertObjectToQueryArrayParams(input) {
+  const result = {};
+
+  input.forEach((item, index) => {
+    Object.keys(item).forEach(key => {
+      const value = item[key];
+
+      if (Array.isArray(value)) {
+        value.forEach((subItem, subIndex) => {
+          result[`${key}[${index}][${subIndex}]`] = subItem;
+        });
+      } else {
+        result[`${key}[${index}]`] = value;
+      }
+    });
+  });
+
+  return result;
+};

--- a/srv/cmis/request-builders.js
+++ b/srv/cmis/request-builders.js
@@ -27,6 +27,11 @@ class CmisRequestBuilder extends OpenApiRequestBuilder {
   }
 }
 
+const getBrowser = queryParameters =>
+  new CmisRequestBuilder('get', '/browser', {
+    queryParameters,
+  });
+
 /**
  * GET from repository root
  * @param {*} repositoryId
@@ -98,6 +103,7 @@ const createBrowserRootByRepositoryIdAndDirectoryPath = (
   );
 
 module.exports = {
+  getBrowser,
   getBrowserRootByRepositoryId,
   getBrowserRootByRepositoryIdAndDirectoryPath,
   getBrowserByRepositoryId,

--- a/test/cmis/Client-01.test.js
+++ b/test/cmis/Client-01.test.js
@@ -49,12 +49,13 @@ describe('CMIS Client', () => {
     expect(result).toHaveProperty(repository.id);
   });
 
+  let folder;
   test('create a folder', async () => {
     const srv = await cds.connect.to('cmis-client');
-    const result = await srv
+    folder = await srv
       .createFolder(repository.id, `${Date.now()}-testFolder`)
       .execute(destination);
-    expect(result).toHaveProperty('succinctProperties');
+    expect(folder).toHaveProperty('succinctProperties');
   });
 
   let document;
@@ -108,6 +109,22 @@ describe('CMIS Client', () => {
 
     expect(result.succinctProperties['cmis:contentStreamLength']).not.toBe(
       document.succinctProperties['cmis:contentStreamLength'],
+    );
+  });
+
+  test('create a document from source', async () => {
+    const srv = await cds.connect.to('cmis-client');
+    const result = await srv
+      .createDocumentFromSource(
+        repository.id,
+        document.succinctProperties['cmis:objectId'],
+        folder.succinctProperties['cmis:objectId'],
+      )
+      .execute(destination);
+
+    expect(result).toHaveProperty('succinctProperties');
+    expect(result.succinctProperties['sap:parentIds']).toContain(
+      folder.succinctProperties['cmis:objectId'],
     );
   });
 
@@ -190,7 +207,7 @@ describe('CMIS Client', () => {
       .execute(destination);
 
     expect(result).toHaveProperty('numItems');
-    expect(result.numItems).toBe(1);
+    expect(result.results.length).toBe(1);
   });
 
   test('download a document', async () => {


### PR DESCRIPTION
The purpose of this PR is to include all the missing methods from the [SDM API available on the SAP API Hub](https://hub.sap.com/package/SAPDocumentManagementServiceIntegrationOptionCMISAPI/rest) into the `cmis-client`.

These are the pending methods:
 - [x] Add Access Control Entries: `addACLProperty`
 - [x] Create Document from Source
 - [ ] Create Favorite
 - [ ] Create Link
 - [ ] Create Secondary Type
 - [ ] Create Share
 - [ ] Delete Tree
 - [ ] Generate Thumbnail
 - [X] Get Access Control List: `getACLProperty`
 - [ ] Get Allowable Actions
 - [ ] Get Children
 - [ ] Get Deleted Children
 - [ ] Get Descendants
 - [ ] Get Folder Tree
 - [ ] Get Parent
 - [ ] Get Properties
 - [ ] Get Type Children
 - [ ] Get Type Definition
 - [ ] Get Type Descendants
 - [ ] Move Object
 - [ ] Permanently Remove the Object
 - [X] Remove Access Control Entries: `removeACLProperty`
 - [ ] Restore Object
 - [ ] Update Folder, Document, Link Object
 - [ ] ZIP Content Creation
 - [ ] ZIP Content Download
 - [ ] ZIP Extract and Upload